### PR TITLE
Correct comment for SafePowerOff() example

### DIFF
--- a/cpp/examples/basic_robot_command/basic_robot_command.cpp
+++ b/cpp/examples/basic_robot_command/basic_robot_command.cpp
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    // Stand up the robot.
+    // Safely power-off the robot.
     bosdyn::api::RobotCommand poweroff_command = ::bosdyn::client::SafePowerOffCommand();
     auto poweroff_res = robot_command_client->RobotCommand(poweroff_command);
     if (!poweroff_res.status) {


### PR DESCRIPTION
This PR simply corrects a mislabelled Power Off comment in the `basic_robot_command` example. Cheers for making an awesome Spot SDK! :beers: 